### PR TITLE
Fix TypeError when converting word vector

### DIFF
--- a/scripts/convert_glove2numpy.py
+++ b/scripts/convert_glove2numpy.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     for i, line in enumerate(lines):
         parts = line.strip().split()
         word = parts[0]
-        vec = np.array(map(float, parts[1:]), dtype='float32')
+        vec = np.array(parts[1:], dtype='float32')
         embed_matrix[i] = vec
         f_wordout.write(word + "\n")
     np.save(embed_path, embed_matrix)


### PR DESCRIPTION
`convert_glove2numpy.py` causes following error.

```
TypeError: float() argument must be a string or a number, not 'map'
```

I think `vec = np.array(parts[1:], dtype='float32')` achieves same objective, without invoking error.