### PR TITLE
Add Keras layer for using compressed embeddings

### DIFF
--- a/nncompress/__init__.py
+++ b/nncompress/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import, division, print_function
 
 from .embed_compress import EmbeddingCompressor
+from .keras import CompressedEmbedding

--- a/nncompress/keras.py
+++ b/nncompress/keras.py
@@ -1,0 +1,80 @@
+import numpy as np
+from keras import backend as K
+from keras.layers import Layer
+from keras.utils.generic_utils import to_list
+
+class CompressedEmbedding(Layer):
+    """Embedding layer which uses compressed embeddings."""
+
+    def __init__(self, codebook, codes, input_length=None, **kwargs):
+        """Initializes a new compressed embedding layer.
+
+        - `codebook` is a matrix of codebooks which map indices to basis vectors
+        - `codes` is a matrix which maps word indices to sequences of integers,
+            representing indexes into each codebook.
+        """
+
+        if 'input_shape' not in kwargs:
+            if input_length:
+                kwargs['input_shape'] = (input_length,)
+            else:
+                kwargs['input_shape'] = (None,)
+
+        assert isinstance(codebook, np.ndarray)
+        assert isinstance(codes, np.ndarray)
+
+        self.codebook_np = codebook
+        self.codes_np = codes
+
+        self.input_length = input_length
+        self.output_dim = codebook.shape[-1]
+
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        self.codebook = K.constant(self.codebook_np, dtype='float32', name='codebook')
+        self.codes = K.constant(self.codes_np, dtype='int32', name='word_codes')
+
+        super().build(input_shape)
+
+    def call(self, x):
+        if K.dtype(x) != 'int32':
+            x = K.cast(x, 'int32')
+
+        # Get the indices into the codebooks
+        codes = K.gather(self.codes, x)
+
+        # Gather the required basis vectors for these words
+        vectors = K.gather(self.codebook, codes)
+
+        # Sum the basis vectors to obtain the embedding vectors
+        embeddings = K.sum(vectors, axis=-2)
+
+        return embeddings
+
+    def compute_output_shape(self, input_shape):
+        """Computes the output shape of this embedding layer.
+
+        Code taken from the original Keras `Embedding` layer.
+        """
+
+        if self.input_length is None:
+            return input_shape + (self.output_dim,)
+
+        # input_length can be tuple if input is 3D or higher
+        in_lens = to_list(self.input_length, allow_tuple=True)
+        if len(in_lens) != len(input_shape) - 1:
+            raise ValueError(
+                '"input_length" is %s, but received input has shape %s' %
+                (str(self.input_length), str(input_shape)))
+
+        for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
+            if s1 is not None and s2 is not None and s1 != s2:
+                raise ValueError(
+                    '"input_length" is %s, but received input has shape %s' %
+                    (str(self.input_length), str(input_shape)))
+
+            if s1 is None:
+                in_lens[i] = s2
+
+        return (input_shape[0],) + tuple(in_lens) + (self.output_dim,)

--- a/nncompress/keras.py
+++ b/nncompress/keras.py
@@ -26,6 +26,8 @@ class CompressedEmbedding(Layer):
         assert isinstance(codebook, np.ndarray)
         assert isinstance(codes, np.ndarray)
         assert len(codebook.shape) == 3
+        
+        self.codebook_count = codebook.shape[0]
 
         self.codebook = K.constant(codebook, dtype='float32', name='codebook')
         self.codes = K.constant(codes, dtype='int32', name='word_codes')
@@ -42,16 +44,16 @@ class CompressedEmbedding(Layer):
         x = tf.cast(x, tf.int32)
 
         # Get the indices into the codebooks
-        codes = tf.gather(self.codes, x)
+        codes = K.gather(self.codes, x)
     
-        indices = tf.broadcast_to(tf.range(self.codebook.shape[0]), codes.shape)
+        indices = tf.broadcast_to(tf.range(self.codebook_count), tf.shape(codes))
         indices = tf.stack([indices, codes], axis=-1)
 
         # Gather the required basis vectors for these words
         vectors = tf.gather_nd(self.codebook, indices)
 
         # Sum the basis vectors to obtain the embedding vectors
-        embeddings = tf.reduce_sum(vectors, axis=-2)
+        embeddings = K.sum(vectors, axis=-2)
 
         return embeddings
 

--- a/nncompress/keras.py
+++ b/nncompress/keras.py
@@ -23,8 +23,8 @@ class CompressedEmbedding(Layer):
         assert isinstance(codebook, np.ndarray)
         assert isinstance(codes, np.ndarray)
 
-        self.codebook_np = codebook
-        self.codes_np = codes
+        self.codebook = K.constant(codebook, dtype='float32', name='codebook')
+        self.codes = K.constant(codes, dtype='int32', name='word_codes')
 
         self.input_length = input_length
         self.output_dim = codebook.shape[-1]
@@ -32,9 +32,6 @@ class CompressedEmbedding(Layer):
         super().__init__(**kwargs)
 
     def build(self, input_shape):
-        self.codebook = K.constant(self.codebook_np, dtype='float32', name='codebook')
-        self.codes = K.constant(self.codes_np, dtype='int32', name='word_codes')
-
         super().build(input_shape)
 
     def call(self, x):


### PR DESCRIPTION
This PR adds a custom Keras layer which can be used to embed words using a codebook and the list of codes.

Partially fixes #7, since we now support Keras as a high-level API.